### PR TITLE
README and pi_dependencies to Python 3.7

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -1,0 +1,23 @@
+# Getting Started
+
+This contains some Python code that will help get you started.
+
+asyncio contains examples that are most suitable for medium to advanced Python coders who understand the asyncio module.
+
+observer contains examples that are most suitable for beginner to medium Python coders who don't have experience with asyncio.
+
+## What Sort of Activities?
+
+In each folder, there are examples that go over:
+
+- Api and Ahell
+- Color Sensor
+- Driving
+- Infrared
+- LED
+- Motors
+- Power
+- Sensor Streaming
+- System
+
+Many of the examples have a couple versions, where one is standard and the other uses the REST API.

--- a/pi_dependencies/pidependencies.sh
+++ b/pi_dependencies/pidependencies.sh
@@ -1,4 +1,4 @@
-sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.5 1
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
 python -m venv env
 source env/bin/activate
 pip install aiohttp

--- a/pi_dependencies/pidependencies.sh
+++ b/pi_dependencies/pidependencies.sh
@@ -1,11 +1,11 @@
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
 python -m venv env
 source env/bin/activate
-pip install aiohttp
-pip install requests
-pip install websocket-client
-pip install pytest-asyncio
-pip install pytest
-pip install twine
-pip install pyserial
-pip install pyserial-asyncio
+pip3 install aiohttp
+pip3 install requests
+pip3 install websocket-client
+pip3 install pytest-asyncio
+pip3 install pytest
+pip3 install twine
+pip3 install pyserial
+pip3 install pyserial-asyncio

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,5 @@
+# Python Projects and Examples
+
+There are a few examples in here.
+
+More indepth articles exist at [this page](https://sdk.sphero.com/docs/samples_content/raspberry_pi/python/rvr_bolt_ir_sample/).

--- a/sphero_sdk/observer/client/dal/serial_observer_port.py
+++ b/sphero_sdk/observer/client/dal/serial_observer_port.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class SerialObserverPort:
-    def __init__(self, parser, port='/dev/ttyS0', baud=115200):
+    def __init__(self, parser, port='/dev/serial0', baud=115200):
         """SerialObserverPort is responsible opening, writing, and reading bytes coming from the UART port.
 
         Args:


### PR DESCRIPTION
Some README stuff that might be helpful to help with navigation and finding tutorials.

A bigger change was pi_dependencies to Python 3.7. I had a problem, so I made a brand new Raspbian install. I still got errors when running ./pi_dependencies and it seems to be based on using Python 3.5 instead of Python 3.7.

My brand new Raspbian install came with Python 3.7, and did not come with Python 3.5. So I changed this to 3.7 and it worked on my install.

This will likely help your users.

Another user in your forum may have noticed the same issue.

https://community.sphero.com/t/rvr-started-shipping-newbie-saying-hi-drop-a-line-and-say-hello/535/5

Thanks :)