### PR TITLE
Add setup.py so sdk can be uploaded to Pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 *.py.un~
 *.DS_Store
 
+MANIFEST
+dist/
+build/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from setuptools import find_packages
+from distutils.core import setup
+
+setup(
+	name='sphero_sdk',
+	version='0.3.4.post2',  # TODO: unify with __version__.py
+	description='Sphero SDK to run on Raspberry Pi using Python',
+	author='Anthony Vizcarra',
+	author_email='Anthony@sphero.com',
+	url='https://github.com/sphero-inc/sphero-sdk-raspberrypi-python',
+	packages=find_packages(include=['sphero_sdk*']),
+	install_requires=[
+		'aiohttp',
+		'pyserial',
+		'pyserial-asyncio',
+	],
+)


### PR DESCRIPTION
I think most python power users would rather use pip to install your SDK, so I've added the boilerplate necessary to get it uploaded to pypi.org; this allows the SDK to be installed a python environment with `pip install sphero-sdk`

I've uploaded the package to pypi already [under my own username](https://pypi.org/project/sphero-sdk/); let me know your pypi.org username and I will transfer ownership to you.