### PR TITLE
Add support to change the serial port in the observer SDK

### DIFF
--- a/sphero_sdk/observer/client/dal/serial_observer_dal.py
+++ b/sphero_sdk/observer/client/dal/serial_observer_dal.py
@@ -14,11 +14,11 @@ logger = logging.getLogger(__name__)
 class SerialObserverDal(SpheroDalBase):
     __slots__ = ['_port']
 
-    def __init__(self):
+    def __init__(self, port='/dev/ttyS0'):
         SpheroDalBase.__init__(self)
         dispatcher = EventDispatcher()
         parser = ObserverParser(dispatcher)
-        self._port = SerialObserverPort(parser)
+        self._port = SerialObserverPort(parser, port=port)
 
     def send_command(self, did, cid, seq, target, timeout=None, inputs=[], outputs=[]):
         """Creates a Message object using the provided parameters and sends it to the serial port.

--- a/sphero_sdk/observer/client/toys/sphero_rvr_observer.py
+++ b/sphero_sdk/observer/client/toys/sphero_rvr_observer.py
@@ -26,11 +26,11 @@ from sphero_sdk import RvrFwCheckObserver
 
 
 class SpheroRvrObserver(Observer, RvrFwCheckObserver):
-    def __init__(self, log_level=LogLevel.Silent):
+    def __init__(self, log_level=LogLevel.Silent, serial_port='/dev/ttyS0'):
         logging.config.dictConfig(logging_config.get_dict(log_level))
         Observer.__init__(self)
         RvrFwCheckObserver.__init__(self)
-        self._dal = SerialObserverDal()
+        self._dal = SerialObserverDal(port=serial_port)
         self._led_control = LedControlObserver(self)
         self._drive_control = DriveControlObserver(self)
         self._infrared_control = InfraredControlObserver(self)


### PR DESCRIPTION
While the `/dev/ttyS0/` might be fine for Raspberry Pi users on the GPIO's serial port, users of other embedded computers or people using USB-to-serial converters need a way to set the serial port.  Currently, this is only supported in the `asyncio` version of the SDK and not the `observer`.  This adds an optional argument to fix that.