### PR TITLE
changed python to python3

### DIFF
--- a/first-time-setup.sh
+++ b/first-time-setup.sh
@@ -17,7 +17,7 @@ tk-dev \
 libffi-dev \
 liblzma-dev
 
-python -m pip install pipenv
+python3 -m pip install pipenv
 
 printf "PATH=$HOME/.local/bin:$PATH\n" >> ~/.profile
 


### PR DESCRIPTION
On the latest version of Raspbian (Linux raspberrypi 5.4.79-v7+ #1373 SMP Mon Nov 23 13:22:33 GMT 2020 armv7l GNU/Linux), whenever I would try to run:
pipenv --python /usr/bin/python3.7
I would get this error: 
ImportError: No module named functools_lru_cache
I tried installing and reinstalling backports.functools-lru-cache with pip and pip3, but I still got the error message.
I then install pipenv using python3 3, and the pipenv finally worked without error.